### PR TITLE
Fix fatal error

### DIFF
--- a/src/Plugin/HandleQueueMessageRejectPlugin.php
+++ b/src/Plugin/HandleQueueMessageRejectPlugin.php
@@ -27,22 +27,22 @@ class HandleQueueMessageRejectPlugin
         QueueInterface $subject,
         callable $proceed,
         EnvelopeInterface $envelope,
-        bool $requeue,
-        string $error
+        bool $requeue = true,
+        string $rejectionMessage = null
     ): void {
-        if (!$error) {
-            $proceed($envelope, $requeue, $error);
+        if (!$rejectionMessage) {
+            $proceed($envelope, $requeue, $rejectionMessage);
             return;
         }
 
         $shouldBeSavedForRetry = $this->isMessageShouldBeSavedForRetryService->execute($envelope);
 
         if (!$shouldBeSavedForRetry) {
-            $proceed($envelope, $requeue, $error);
+            $proceed($envelope, $requeue, $rejectionMessage);
             return;
         }
 
-        $this->saveFailedMessageService->execute($envelope, $error);
+        $this->saveFailedMessageService->execute($envelope, $rejectionMessage);
         $subject->acknowledge($envelope);
     }
 }


### PR DESCRIPTION
We were getting the following fatal error

`Error when running a cron job: Too few arguments to function RunAsRoot\MessageQueueRetry\Plugin\HandleQueueMessageRejectPlugin::aroundReject(), 3 passed in vendor/magento/framework/Interception/Interceptor.php on line 135 and exactly 5 expected`

I made plugin method arguments optional as in the original method to avoid fatal error regarding arguments count